### PR TITLE
Source Google Ads: Include audience and user_interest to full-refresh ingestion

### DIFF
--- a/airbyte-integrations/connectors/source-google-ads/Dockerfile
+++ b/airbyte-integrations/connectors/source-google-ads/Dockerfile
@@ -13,5 +13,5 @@ COPY main.py ./
 
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.2.13
+LABEL io.airbyte.version=0.2.14
 LABEL io.airbyte.name=airbyte/source-google-ads

--- a/airbyte-integrations/connectors/source-google-ads/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-google-ads/integration_tests/configured_catalog.json
@@ -246,6 +246,24 @@
       },
       "sync_mode": "full_refresh",
       "destination_sync_mode": "overwrite"
+    },
+    {
+      "stream": {
+        "name": "audience",
+        "json_schema": {},
+        "supported_sync_modes": ["full_refresh"]
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
+    },
+    {
+      "stream": {
+        "name": "user_interest",
+        "json_schema": {},
+        "supported_sync_modes": ["full_refresh"]
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/google_ads.py
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/google_ads.py
@@ -32,6 +32,8 @@ REPORT_MAPPING = {
     "click_view": "click_view",
     "geographic_report": "geographic_view",
     "keyword_report": "keyword_view",
+    "audience": "audience",
+    "user_interest": "user_interest",
 }
 API_VERSION = "v13"
 logger = logging.getLogger("airbyte")

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/schemas/audience.json
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/schemas/audience.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "audience.description": {
+      "type": ["null", "string"]
+    },
+    "audience.dimensions": {
+      "type": ["null", "array"],
+      "audience_segments": {
+        "type": "string"
+      }
+    },
+    "audience.exclusion_dimension": {
+      "type": ["null", "array"],
+      "exclusions": {
+        "type": "string"
+      }
+    },
+    "audience.id": {
+      "type": ["null", "integer"]
+    },
+    "audience.name": {
+      "type": ["null", "string"]
+    },
+    "audience.resource_name": {
+      "type": ["null", "string"]
+    },
+    "audience.status": {
+      "type": ["null", "string"],
+      "enum": [
+        "ENABLED",
+        "REMOVED",
+        "UNKNOWN",
+        "UNSPECIFIED"
+      ]
+    }
+  }
+}

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/schemas/user_interest.json
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/schemas/user_interest.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "user_interest.availabilities": {
+      "type": ["null", "array"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "user_interest.user_interest_id": {
+      "type": ["null", "integer"]
+    },
+    "user_interest.name": {
+      "type": ["null", "string"]
+    },
+    "user_interest.resource_name": {
+      "type": ["null", "string"]
+    },
+    "user_interest.user_interest_parent": {
+      "type": ["null", "string"]
+    }
+  }
+}

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/source.py
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/source.py
@@ -24,6 +24,7 @@ from .streams import (
     AdGroupAds,
     AdGroupLabels,
     AdGroups,
+    Audience,
     CampaignLabels,
     Campaigns,
     ClickView,
@@ -34,6 +35,7 @@ from .streams import (
     ServiceAccounts,
     ShoppingPerformanceReport,
     UserLocationReport,
+    UserInterest,
 )
 from .utils import GAQL
 
@@ -134,8 +136,10 @@ class SourceGoogleAds(AbstractSource):
             AdGroups(**incremental_config),
             AdGroupLabels(google_api, customers=customers),
             Accounts(**incremental_config),
+            Audience(google_api, customers=customers),
             CampaignLabels(google_api, customers=customers),
             ClickView(**incremental_config),
+            UserInterest(google_api, customers=customers),
         ]
         # Metrics streams cannot be requested for a manager account.
         if non_manager_accounts:

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/streams.py
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/streams.py
@@ -288,6 +288,19 @@ class ServiceAccounts(GoogleAdsStream):
     CATCH_API_ERRORS = False
     primary_key = ["customer.id"]
 
+class Audience(GoogleAdsStream):
+    """
+    Audience stream: https://developers.google.com/google-ads/api/fields/v11/audience
+    """
+    transformer = TypeTransformer(TransformConfig.DefaultSchemaNormalization)
+    primary_key = ["audience.id"]
+
+class UserInterest(GoogleAdsStream):
+    """
+    Audience stream: https://developers.google.com/google-ads/api/fields/v11/user_interest
+    """
+
+    primary_key = ["user_interest.user_interest_id"]
 
 class Campaigns(IncrementalGoogleAdsStream):
     """


### PR DESCRIPTION
## What
Added the audience and user_interest in the integration process. They are presented in the airbyte platform, as presented in the following image, to perform data integration with Google Ads. They can be integrated on full-refresh append/overwrite.

![image](https://user-images.githubusercontent.com/5081890/229205030-11fea5e3-a2c0-4ef2-9b6f-2708cb7c1c18.png)

## How
Included audience and user_interest to the Source of Google Ads.

